### PR TITLE
Fix ColorPicker crash

### DIFF
--- a/src/com/discovery/settings/notificationlight/LightSettingsDialog.java
+++ b/src/com/discovery/settings/notificationlight/LightSettingsDialog.java
@@ -306,6 +306,7 @@ public class LightSettingsDialog extends AlertDialog implements
         final Notification.Builder builder = new Notification.Builder(getContext());
         builder.setLights(color, speedOn, speedOff);
         builder.setExtras(b);
+        builder.setSmallIcon(R.drawable.no_icon);
 
         mNotificationManager.notify(1, builder.build());
     }


### PR DESCRIPTION
Solves "Invalid notification (no valid small icon): " in frameworks/base/core/java/android/app/NotificationManager.java